### PR TITLE
Launch.json to avoid exception

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,6 +37,7 @@
       "name": ".NET Core Launch (ConsoleClient)",
       "type": "coreclr",
       "request": "launch",
+      "console":"externalTerminal",
       "preLaunchTask": "build-ConsoleClient",
       // If you have changed target frameworks, make sure to update the program path.
       "program": "${workspaceRoot}/samples/ConsoleClient/bin/Debug/netcoreapp2.2/ConsoleClient.dll",


### PR DESCRIPTION
On windows, if you have bash as vscode the integrated terminal an exception
`Exception has occurred: CLR/System.InvalidOperationException An unhandled exception of type 'System.InvalidOperationException' occurred in System.Console.dll: 'Cannot read keys when either application does not have a console or when console input has been redirected. Try Console.Read.'`
is raised.
Setting the console to "externalTerminal" solves this problem.
Just  minimal setting adjustment, but avoids spending 3 minutes to google for it and fix it.